### PR TITLE
Run Array Types Through the Full Type Validation

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -189,7 +189,7 @@ class Validator
     public static function validateType($typeName)
     {
         if (substr($typeName, -2) == "[]") {
-            return self::validateNamingConvention(substr($typeName, 0, -2)) . "[]";
+            return self::validateType(substr($typeName, 0, -2)).'[]';
         }
 
         switch (strtolower($typeName)) {

--- a/tests/src/Unit/ValidatorTest.php
+++ b/tests/src/Unit/ValidatorTest.php
@@ -75,4 +75,19 @@ class ValidatorTest extends UnitTestCase
         $this->assertEquals('validarContrasena[]', Validator::validateType('validarContraseña[]')); //UTF-8 array type
     }
 
+    /**
+     * @group https://github.com/AgencyPMG/wsdl2phpgenerator/issues/3
+     */
+    public function testValidateBuildIntTypeArrayTypeValidatesTheOriginalType()
+    {
+        $this->assertEquals('int[]', Validator::validateType('long[]'));
+    }
+
+    /**
+     * @group https://github.com/AgencyPMG/wsdl2phpgenerator/issues/3
+     */
+    public function testVAlidateWithClassTypeArrayValidatesTheOriginalClass()
+    {
+        $this->assertEquals('Foo[]', Validator::validateType('Foo[]'));
+    }
 }


### PR DESCRIPTION
Rather than just validating naming conventions. This ensures that things like `long[]` types end up as `int[]` like they should.