### PR TITLE
Use IteratorAggregate in ArrayType

### DIFF
--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -137,88 +137,22 @@ class ArrayType extends ComplexType
 
     protected function implementIterator()
     {
-        $this->class->addImplementation('\\Iterator');
-        $description = 'Iterator implementation';
+        $this->class->addImplementation('\\IteratorAggregate');
 
-        $currentDock = new PhpDocComment();
-        $currentDock->setDescription($description);
-        $currentDock->setReturn(PhpDocElementFactory::getReturn($this->arrayOf, 'Return the current element'));
-        $current = new PhpFunction(
+        $docblock = new PhpDocComment();
+        $docblock->setDescription('Traversable Implementation');
+        $docblock->setReturn(PhpDocElementFactory::getReturn($this->arrayOf.'[]', 'Return an iterator of the elements'));
+        $iter = new PhpFunction(
             'public',
-            'current',
-            $this->buildParametersString(
-                array(),
-                false,
-                false
+            'getIterator',
+            $this->buildParametersString(array(), false, false),
+            sprintf(
+                '    return new \ArrayIterator($this->%s);',
+                $this->field->getName()
             ),
-            '  return current($this->' . $this->field->getName() . ');',
-            $currentDock
+            $docblock
         );
-        $this->class->addFunction($current);
-
-        $nextDock = new PhpDocComment();
-        $nextDock->setDescription($description . PHP_EOL . 'Move forward to next element');
-        $nextDock->setReturn(PhpDocElementFactory::getReturn('void', ''));
-        $next = new PhpFunction(
-            'public',
-            'next',
-            $this->buildParametersString(
-                array(),
-                false,
-                false
-            ),
-            '  next($this->' . $this->field->getName() . ');',
-            $nextDock
-        );
-        $this->class->addFunction($next);
-
-        $keyDock = new PhpDocComment();
-        $keyDock->setDescription($description);
-        $keyDock->setReturn(PhpDocElementFactory::getReturn('string|null', 'Return the key of the current element or null'));
-        $key = new PhpFunction(
-            'public',
-            'key',
-            $this->buildParametersString(
-                array(),
-                false,
-                false
-            ),
-            '  return key($this->' . $this->field->getName() . ');',
-            $keyDock
-        );
-        $this->class->addFunction($key);
-
-        $validDock = new PhpDocComment();
-        $validDock->setDescription($description);
-        $validDock->setReturn(PhpDocElementFactory::getReturn('boolean', 'Return the validity of the current position'));
-        $valid = new PhpFunction(
-            'public',
-            'valid',
-            $this->buildParametersString(
-                array(),
-                false,
-                false
-            ),
-            '  return $this->key() !== null;',
-            $validDock
-        );
-        $this->class->addFunction($valid);
-
-        $rewindDock = new PhpDocComment();
-        $rewindDock->setDescription($description . PHP_EOL . 'Rewind the Iterator to the first element');
-        $rewindDock->setReturn(PhpDocElementFactory::getReturn('void', ''));
-        $rewind = new PhpFunction(
-            'public',
-            'rewind',
-            $this->buildParametersString(
-                array(),
-                false,
-                false
-            ),
-            '  reset($this->' . $this->field->getName() . ');',
-            $rewindDock
-        );
-        $this->class->addFunction($rewind);
+        $this->class->addFunction($iter);
     }
 
     protected function implementCountable()

--- a/tests/src/Functional/NaicsTest.php
+++ b/tests/src/Functional/NaicsTest.php
@@ -63,7 +63,7 @@ class NaicsTest extends FunctionalTestCase
     protected function checkArray($arrayClass, $array)
     {
         $this->assertClassImplementsInterface($arrayClass, 'ArrayAccess');
-        $this->assertClassImplementsInterface($arrayClass, 'Iterator');
+        $this->assertClassImplementsInterface($arrayClass, 'Traversable');
         $this->assertClassImplementsInterface($arrayClass, 'Countable');
 
         $this->assertEquals(count($arrayClass), count($array));

--- a/tests/src/Unit/ArrayTypeTest.php
+++ b/tests/src/Unit/ArrayTypeTest.php
@@ -61,7 +61,7 @@ class ArrayTypeTest extends CodeGenerationTestCase
     {
         $this->assertClassExists($this->testClassName);
         $this->assertClassImplementsInterface($this->testClassName, 'ArrayAccess');
-        $this->assertClassImplementsInterface($this->testClassName, 'Iterator');
+        $this->assertClassImplementsInterface($this->testClassName, 'Traversable');
         $this->assertClassImplementsInterface($this->testClassName, 'Countable');
     }
 
@@ -104,11 +104,7 @@ class ArrayTypeTest extends CodeGenerationTestCase
      */
     public function testIteratorImplementation()
     {
-        $this->assertClassHasMethod($this->testClassName, 'current');
-        $this->assertClassHasMethod($this->testClassName, 'key');
-        $this->assertClassHasMethod($this->testClassName, 'next');
-        $this->assertClassHasMethod($this->testClassName, 'rewind');
-        $this->assertClassHasMethod($this->testClassName, 'valid');
+        $this->assertClassHasMethod($this->testClassName, 'getIterator');
 
         // Test all Iterator methods
         // (both cycles must pass)


### PR DESCRIPTION
Instead of `Iterator`. Less generated code. Same impact: users can still
`foreach` through the array classes.

Closes #8 