### PR TITLE
Add an `exchangeArray` Method to Generated ArrayOf* Classes

### DIFF
--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -177,6 +177,28 @@ class ArrayType extends ComplexType
         $this->class->addFunction($count);
     }
 
+    protected function implementExchangeArray()
+    {
+        $doc = new PhpDocComment();
+        $doc->setDescription('Change the current array with another');
+        $doc->setReturn(PhpDocElementFactory::getReturn($this->arrayOf.'[]|null', 'The previous array if present'));
+        $ex = new PhpFunction(
+            'public',
+            'exchangeArray',
+            $this->buildParametersString([
+                $this->field->getName() => 'array',
+            ], true, false),
+            implode(PHP_EOL, [
+                sprintf('    $prev = $this->%s;', $this->field->getName()),
+                sprintf('    $this->%1$s = $%1$s;', $this->field->getName()),
+                '    return $prev;'
+            ]),
+            $doc
+        );
+
+        $this->class->addFunction($ex);
+    }
+
     protected function implementArrayInterfaces()
     {
         $members = array_values($this->members);
@@ -186,5 +208,6 @@ class ArrayType extends ComplexType
         $this->implementArrayAccess();
         $this->implementIterator();
         $this->implementCountable();
+        $this->implementExchangeArray();
     }
 }

--- a/tests/src/Unit/ArrayTypeTest.php
+++ b/tests/src/Unit/ArrayTypeTest.php
@@ -134,4 +134,17 @@ class ArrayTypeTest extends CodeGenerationTestCase
 
         $this->assertCount(count($this->items), $this->class);
     }
+
+    /**
+     * @group https://github.com/AgencyPMG/wsdl2phpgenerator/issues/7
+     */
+    public function testGeneratedClassHasExchangeArrayImplemented()
+    {
+        $this->assertClassHasMethod($this->testClassName, 'exchangeArray');
+
+        $prev = $this->class->exchangeArray(['changed']);
+
+        $this->assertSame($this->items, $prev);
+        $this->assertSame(['changed'], iterator_to_array($this->class));
+    }
 }


### PR DESCRIPTION
Makes it a bit more easy to programmatically deal with changing the
array in an ArrayOf type

Closes #7 