### PR TITLE
Introduce a `TypeRegistry` Object

### DIFF
--- a/src/Filter/ServiceOperationFilter.php
+++ b/src/Filter/ServiceOperationFilter.php
@@ -7,6 +7,7 @@ use Wsdl2PhpGenerator\ConfigInterface;
 use Wsdl2PhpGenerator\Enum;
 use Wsdl2PhpGenerator\Service;
 use Wsdl2PhpGenerator\Type;
+use Wsdl2PhpGenerator\TypeRegistry;
 use Wsdl2PhpGenerator\Variable;
 
 /**
@@ -58,10 +59,8 @@ class ServiceOperationFilter implements FilterInterface
             }
             // Discover types used in returns
             $returns = $operation->getReturns();
-
-            $type = $service->getType($returns);
-            if ($type !== null) {
-                $methodTypes[] = $type;
+            if ($returns && ($returnType = $service->getType($returns))) {
+                $methodTypes[] = $returnType;
             }
 
             foreach ($methodTypes as $type) {
@@ -73,7 +72,12 @@ class ServiceOperationFilter implements FilterInterface
         // Remove duplicated using standard equality checks. Default string
         // comparison does not work here.
         $types = array_unique($types, SORT_REGULAR);
-        $filteredService = new Service($this->config, $service->getIdentifier(), $types, $service->getDescription());
+        $filteredService = new Service(
+            $this->config,
+            $service->getIdentifier(),
+            TypeRegistry::fromIterable($types),
+            $service->getDescription()
+        );
         // Pull created service with operations
         foreach ($operations as $operation) {
             $filteredService->addOperation($operation);

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -55,7 +55,7 @@ class Generator implements GeneratorInterface
     public function __construct()
     {
         $this->service = null;
-        $this->types = array();
+        $this->types = new TypeRegistry();
     }
 
     /**
@@ -103,7 +103,7 @@ class Generator implements GeneratorInterface
 
         $this->wsdl = new WsdlDocument($this->config, $wsdl);
 
-        $this->types = array();
+        $this->types = new TypeRegistry();
 
         $this->loadTypes();
         $this->loadService();
@@ -179,7 +179,7 @@ class Generator implements GeneratorInterface
                     }
                 }
                 if (!$already_registered) {
-                    $this->types[$typeNode->getName()] = $type;
+                    $this->types->add($type);
                 }
             }
         }
@@ -188,8 +188,10 @@ class Generator implements GeneratorInterface
         // We can only do this once all types have been loaded. Otherwise we risk referencing types which have not been
         // loaded yet.
         foreach ($types as $type) {
-            if (($baseType = $type->getBase()) && isset($this->types[$baseType]) && $this->types[$baseType] instanceof ComplexType) {
-                $this->types[$type->getName()]->setBaseType($this->types[$baseType]);
+            if (($baseType = $type->getBase()) && $this->types->get($baseType) instanceof ComplexType) {
+                $this->types->get($type->getName())->setBaseType(
+                    $this->types->get($baseType)
+                );
             }
         }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,15 +50,6 @@ class Generator implements GeneratorInterface
     protected $logger;
 
     /**
-     * Construct the generator
-     */
-    public function __construct()
-    {
-        $this->service = null;
-        $this->types = new TypeRegistry();
-    }
-
-    /**
      * Generates php source code from a wsdl file
      *
      * @param ConfigInterface $config The config to use for generation

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -49,6 +49,11 @@ class Generator implements GeneratorInterface
      */
     protected $logger;
 
+    public function __construct()
+    {
+        // noop
+    }
+
     /**
      * Generates php source code from a wsdl file
      *

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -76,10 +76,10 @@ class Operation
     }
 
     /**
-     * @param Type[] $validTypes An array of Type objects with valid types for typehinting
+     * @param TypeRegistry $validTypes An array of Type objects with valid types for typehinting
      * @return string A parameter string
      */
-    public function getParamString(array $validTypes)
+    public function getParamString(TypeRegistry $validTypes)
     {
         $params = array();
 
@@ -90,13 +90,9 @@ class Operation
             if ($typeHint == 'array') {
                 $ret .= $typeHint . ' ';
             } else {
-                foreach ($validTypes as $type) {
-                    if ($type instanceof ComplexType) {
-                        if ($typeHint == $type->getPhpIdentifier()) {
-                            $ret .= $typeHint . ' ';
-                            break;
-                        }
-                    }
+                $type = $validTypes->getByPhpIdentifier($typeHint);
+                if ($type instanceof ComplexType) {
+                    $ret .= $typeHint . ' ';
                 }
             }
 
@@ -113,10 +109,10 @@ class Operation
     /**
      *
      * @param string $name The param to get
-     * @param array An array of Type objects with valid types for typehinting
+     * @param TypeRegistry $validTypes The type objects with valid types for typehinting
      * @return array A array with three keys 'type' => the typehint to use 'name' => the name of the param and 'desc' => A description of the param
      */
-    public function getPhpDocParams($name, array $validTypes)
+    public function getPhpDocParams($name, TypeRegistry $validTypes)
     {
         $ret = array();
 
@@ -131,17 +127,16 @@ class Operation
 
         $ret['type'] = $paramType;
 
-        foreach ($validTypes as $type) {
-            if ($paramType == $type->getIdentifier()) {
-                if ($type instanceof Pattern) {
-                    $ret['type'] = $type->getDatatype();
-                    $ret['desc'] = 'Restriction pattern: ' . $type->getValue();
-                } else {
-                    $ret['type'] = $type->getPhpIdentifier();
+        $type = $validTypes->get($paramType);
+        if ($type) {
+            if ($type instanceof Pattern) {
+                $ret['type'] = $type->getDatatype();
+                $ret['desc'] = 'Restriction pattern: ' . $type->getValue();
+            } else {
+                $ret['type'] = $type->getPhpIdentifier();
 
-                    if ($type instanceof Enum) {
-                        $ret['desc'] = 'Constant: ' . $type->getDatatype() . ' - ' . 'Valid values: ' . $type->getValidValues();
-                    }
+                if ($type instanceof Enum) {
+                    $ret['desc'] = 'Constant: ' . $type->getDatatype() . ' - ' . 'Valid values: ' . $type->getValidValues();
                 }
             }
         }

--- a/src/Service.php
+++ b/src/Service.php
@@ -54,19 +54,16 @@ class Service implements ClassGenerator
     /**
      * @param ConfigInterface $config Configuration
      * @param string $identifier The name of the service
-     * @param array $types The types the service knows about
+     * @param TypeRegistery $types The types the service knows about
      * @param string $description The description of the service
      */
-    public function __construct(ConfigInterface $config, $identifier, iterable $types, $description)
+    public function __construct(ConfigInterface $config, $identifier, TypeRegistry $types, $description)
     {
         $this->config = $config;
         $this->identifier = $identifier;
         $this->description = $description;
         $this->operations = array();
-        $this->types = array();
-        foreach ($types as $type) {
-            $this->types[$type->getIdentifier()] = $type;
-        }
+        $this->types = $types;
     }
 
     /**
@@ -120,14 +117,14 @@ class Service implements ClassGenerator
      *
      * @return Type|null The type or null if the type does not exist.
      */
-    public function getType($identifier)
+    public function getType(string $identifier)
     {
-        return isset($this->types[$identifier])? $this->types[$identifier]: null;
+        return $this->types->get($identifier);
     }
     /**
      * Returns all types defined by the service.
      *
-     * @return Type[] An array of types.
+     * @return TypeRegistry An array of types.
      */
     public function getTypes()
     {

--- a/src/Service.php
+++ b/src/Service.php
@@ -57,7 +57,7 @@ class Service implements ClassGenerator
      * @param array $types The types the service knows about
      * @param string $description The description of the service
      */
-    public function __construct(ConfigInterface $config, $identifier, array $types, $description)
+    public function __construct(ConfigInterface $config, $identifier, iterable $types, $description)
     {
         $this->config = $config;
         $this->identifier = $identifier;

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -10,6 +10,16 @@ class TypeRegistry implements \IteratorAggregate
     private $typesByIdentifier = [];
     private $typesByPhpIdentifier = [];
 
+    public static function fromIterable(iterable $types) : self
+    {
+        $out = new self();
+        foreach ($types as $type) {
+            $out->add($type);
+        }
+
+        return $out;
+    }
+
     public function has(string $identifier) : bool
     {
         return isset($this->typesByIdentifier[$identifier]);

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -35,9 +35,10 @@ class TypeRegistry implements \IteratorAggregate
         return $this->typesByPhpIdentifier[$phpIdentifier] ?? null;
     }
 
-    public function add(Type $type) : void
+    public function add(Type $type, ?string $identifierOverride=null) : void
     {
-        $this->typesByIdentifier[$type->getIdentifier()] = $type;
+        $id = $identifierOverride ?? $type->getIdentifier();
+        $this->typesByIdentifier[$id] = $type;
         $this->typesByPhpIdentifier[$type->getPhpIdentifier()] = $type;
     }
 

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -7,30 +7,37 @@ namespace Wsdl2PhpGenerator;
 
 class TypeRegistry implements \IteratorAggregate
 {
-    private $types = [];
+    private $typesByIdentifier = [];
+    private $typesByPhpIdentifier = [];
 
-    public function has(string $typename) : bool
+    public function has(string $identifier) : bool
     {
-        return isset($this->types[$typename]);
+        return isset($this->typesByIdentifier[$identifier]);
     }
 
-    public function get(string $typename) : ?Type
+    public function get(string $identifier) : ?Type
     {
-        return $this->types[$typename] ?? null;
+        return $this->typesByIdentifier[$identifier] ?? null;
+    }
+
+    public function getByPhpIdentifier(string $phpIdentifier) : ?Type
+    {
+        return $this->typesByPhpIdentifier[$phpIdentifier] ?? null;
     }
 
     public function add(Type $type) : void
     {
-        $this->types[$type->getIdentifier()] = $type;
+        $this->typesByIdentifier[$type->getIdentifier()] = $type;
+        $this->typesByPhpIdentifier[$type->getPhpIdentifier()] = $type;
     }
 
-    public function remove(string $typename) : void
+    public function remove(string $identifier) : void
     {
-        unset($this->types[$typename]);
+        unset($this->typesByIdentifier[$identifier]);
     }
 
     public function getIterator() : \ArrayIterator
     {
-        return new \ArrayIterator($this->types);
+        return new \ArrayIterator($this->typesByIdentifier);
     }
 }

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/**
+ * @package Wsdl2PhpGenerator
+ */
+namespace Wsdl2PhpGenerator;
+
+class TypeRegistry implements \IteratorAggregate
+{
+    private $types = [];
+
+    public function has(string $typename) : bool
+    {
+        return isset($this->types[$typename]);
+    }
+
+    public function get(string $typename) : ?Type
+    {
+        return $this->types[$typename] ?? null;
+    }
+
+    public function add(Type $type) : void
+    {
+        $this->types[$type->getIdentifier()] = $type;
+    }
+
+    public function remove(string $typename) : void
+    {
+        unset($this->types[$typename]);
+    }
+
+    public function getIterator() : \ArrayIterator
+    {
+        return new \ArrayIterator($this->types);
+    }
+}

--- a/tests/src/Unit/Filter/ServiceOperationFilterTest.php
+++ b/tests/src/Unit/Filter/ServiceOperationFilterTest.php
@@ -7,6 +7,7 @@ use Wsdl2PhpGenerator\ConfigInterface;
 use Wsdl2PhpGenerator\Enum;
 use Wsdl2PhpGenerator\Filter\ServiceOperationFilter;
 use Wsdl2PhpGenerator\Operation;
+use Wsdl2PhpGenerator\TypeRegistry;
 use Wsdl2PhpGenerator\Service;
 use Wsdl2PhpGenerator\Tests\Unit\UnitTestCase;
 
@@ -120,7 +121,7 @@ class ServiceOperationFilterTest extends UnitTestCase
             $bookType,
             $requestSetVersion
         );
-        $service = new Service($this->config, 'Book_Shell', $types, 'Book shells');
+        $service = new Service($this->config, 'Book_Shell', TypeRegistry::fromIterable($types), 'Book shells');
         $service->addOperation($getBookOperation);
         $service->addOperation($getAuthorsOperator);
         $service->addOperation($setVersionOperator);

--- a/tests/src/Unit/ServiceTest.php
+++ b/tests/src/Unit/ServiceTest.php
@@ -6,6 +6,7 @@ namespace Wsdl2PhpGenerator\Tests\Unit;
 
 use Wsdl2PhpGenerator\Config;
 use Wsdl2PhpGenerator\Service;
+use Wsdl2PhpGenerator\TypeRegistry;
 use Wsdl2PhpGenerator\Tests\Functional\FunctionalTestCase;
 
 /**
@@ -44,7 +45,7 @@ class ServiceTest extends CodeGenerationTestCase
                 'soapClientOptions' => $this->soapclientOptions,
             ));
 
-        $service = new Service($config, 'TestService', array(), 'Service description');
+        $service = new Service($config, 'TestService', new TypeRegistry(), 'Service description');
         $this->generateClass($service, $this->namespace);
 
         $this->assertClassExists('TestService', $this->namespace);

--- a/tests/src/Unit/TypeRegistryTest.php
+++ b/tests/src/Unit/TypeRegistryTest.php
@@ -62,6 +62,14 @@ class TypeRegistryTest extends CodeGenerationTestCase
         $this->assertTrue($this->types->has('OtherType'));
     }
 
+    public function testAddWithIdentifierOverrideUsesTheOverridenIdentifierAsKey()
+    {
+        $this->types->add($this->createType('SomeType'), 'OverrideIdent');
+
+        $this->assertTrue($this->types->has('OverrideIdent'));
+        $this->assertFalse($this->types->has('SomeType'));
+    }
+
     protected function setUp()
     {
         $this->types = new TypeRegistry();

--- a/tests/src/Unit/TypeRegistryTest.php
+++ b/tests/src/Unit/TypeRegistryTest.php
@@ -2,6 +2,8 @@
 
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
+use Wsdl2PhpGenerator\Config;
+use Wsdl2PhpGenerator\ComplexType;
 use Wsdl2PhpGenerator\Type;
 use Wsdl2PhpGenerator\TypeRegistry;
 
@@ -21,38 +23,36 @@ class TypeRegistryTest extends CodeGenerationTestCase
 
     public function testTypesThatAreRegisteredReturnTrueFromHas()
     {
-        $type = $this->createMock(Type::class);
-        $type->expects($this->once())
-            ->method('getIdentifier')
-            ->willReturn('SomeType');
-        $this->types->add($type);
+        $this->types->add($this->createType('SomeType'));
 
         $this->assertTrue($this->types->has('SomeType'));
     }
 
     public function testTypesThatAreRegisteredAreReturnsFromGet()
     {
-        $type = $this->createMock(Type::class);
-        $type->expects($this->once())
-            ->method('getIdentifier')
-            ->willReturn('SomeType');
+        $type = $this->createType('SomeType');
         $this->types->add($type);
 
         $this->assertSame($type, $this->types->get('SomeType'));
     }
 
+    public function testUnregisteredTypesReturnNullFromGetByPhpIdentifier()
+    {
+        $this->assertNull($this->types->getByPhpIdentifier('SomeType'));
+    }
+
+    public function testRegisterTypesReturnTypeObjectFromGetByPhpIdentifier()
+    {
+        $type = $this->createType('SomeType');
+        $this->types->add($type);
+
+        $this->assertSame($type, $this->types->getByPhpIdentifier('SomeType'));
+    }
+
     public function testTypesCanBeRemovedFromTheRegistry()
     {
-        $t1 = $this->createMock(Type::class);
-        $t1->expects($this->once())
-            ->method('getIdentifier')
-            ->willReturn('SomeType');
-        $t2 = $this->createMock(Type::class);
-        $t2->expects($this->once())
-            ->method('getIdentifier')
-            ->willReturn('OtherType');
-        $this->types->add($t1);
-        $this->types->add($t2);
+        $this->types->add($this->createType('SomeType'));
+        $this->types->add($this->createType('OtherType'));
         $this->assertTrue($this->types->has('SomeType'));
         $this->assertTrue($this->types->has('OtherType'));
 
@@ -65,5 +65,13 @@ class TypeRegistryTest extends CodeGenerationTestCase
     protected function setUp()
     {
         $this->types = new TypeRegistry();
+    }
+
+    protected function createType(string $name) : Type
+    {
+        return new ComplexType(new Config([
+            'inputFile' => __FILE__,
+            'outputDir' => __DIR__,
+        ]), $name);
     }
 }

--- a/tests/src/Unit/TypeRegistryTest.php
+++ b/tests/src/Unit/TypeRegistryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Wsdl2PhpGenerator\Tests\Unit;
+
+use Wsdl2PhpGenerator\Type;
+use Wsdl2PhpGenerator\TypeRegistry;
+
+class TypeRegistryTest extends CodeGenerationTestCase
+{
+    private $types;
+
+    public function testTypesThatAreNotRegisteredReturnFalseFromHas()
+    {
+        $this->assertFalse($this->types->has('SomeType'));
+    }
+
+    public function testTypesThatAreNotRegisteredReturnNullFromGet()
+    {
+        $this->assertNull($this->types->get('SomeType'));
+    }
+
+    public function testTypesThatAreRegisteredReturnTrueFromHas()
+    {
+        $type = $this->createMock(Type::class);
+        $type->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('SomeType');
+        $this->types->add($type);
+
+        $this->assertTrue($this->types->has('SomeType'));
+    }
+
+    public function testTypesThatAreRegisteredAreReturnsFromGet()
+    {
+        $type = $this->createMock(Type::class);
+        $type->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('SomeType');
+        $this->types->add($type);
+
+        $this->assertSame($type, $this->types->get('SomeType'));
+    }
+
+    public function testTypesCanBeRemovedFromTheRegistry()
+    {
+        $t1 = $this->createMock(Type::class);
+        $t1->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('SomeType');
+        $t2 = $this->createMock(Type::class);
+        $t2->expects($this->once())
+            ->method('getIdentifier')
+            ->willReturn('OtherType');
+        $this->types->add($t1);
+        $this->types->add($t2);
+        $this->assertTrue($this->types->has('SomeType'));
+        $this->assertTrue($this->types->has('OtherType'));
+
+        $this->types->remove('SomeType');
+
+        $this->assertFalse($this->types->has('SomeType'));
+        $this->assertTrue($this->types->has('OtherType'));
+    }
+
+    protected function setUp()
+    {
+        $this->types = new TypeRegistry();
+    }
+}


### PR DESCRIPTION
Previously we had types as an array passed around, but to support #12 we need to be able to pass in a `$types` object that will not necessarily be loaded until class generation is in progress. An array isn't going to cut it for that.

This also includes some optimizations that skip iterating through every type to generate operation params and docblocks and such.