### PR TITLE
Use the Underlying Enum Types When Generating Complex Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ The following formats are supported:
 
 The proxy information is used by is used when accessing the WSDL to generate the code and for subsequent requests to the SOAP service.
 
+#### `useUnderlyingEnumTypes`
+
+This will swap out enum class names in `@param`, `@var`, and `@returns` docblock
+annotations and typehints for all enum properties on complex types.
+
 ##### Example usage
 
 The following configuration will use a proxy to access the [Google DoubleClick Ad Exchange Buyer SOAP API](https://developers.google.com/ad-exchange/buyer-soap/):

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -108,8 +108,19 @@ class ComplexType extends Type
             $type = Validator::validateType($member->getType());
             $name = Validator::validateAttribute($member->getName());
             $typeHint = Validator::validateTypeHint($type);
+            $otherType = $this->otherTypes->get($type);
+            $docDescription = '';
+            if ($otherType instanceof Enum) {
+                $docDescription = sprintf(
+                    '@see %s for valid values',
+                    $otherType->getPhpNamespacedIdentifier()
+                );
+                $type = $otherType->getDatatype();
+                $typeHint = Validator::validateTypeHint($type);
+            }
 
             $comment = new PhpDocComment();
+            $comment->setDescription($docDescription);
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
             $var = new PhpVariable('protected', $name, 'null', $comment);
             $this->class->addVariable($var);

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -41,17 +41,24 @@ class ComplexType extends Type
     protected $abstract;
 
     /**
+     * @var TypeRegistry
+     */
+    private $otherTypes;
+
+    /**
      * Construct the object
      *
      * @param ConfigInterface $config The configuration
      * @param string $name The identifier for the class
+     * @param $otherTypes Other types available to the complex type. Pass this to get better doc blocks for enums
      */
-    public function __construct(ConfigInterface $config, $name)
+    public function __construct(ConfigInterface $config, $name, TypeRegistry $otherTypes=null)
     {
         parent::__construct($config, $name, null);
         $this->members = array();
         $this->baseType = null;
         $this->abstract = false;
+        $this->otherTypes = $otherTypes ?? new TypeRegistry();
     }
 
     /**

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -110,7 +110,7 @@ class ComplexType extends Type
             $typeHint = Validator::validateTypeHint($type);
             $otherType = $this->otherTypes->get($type);
             $docDescription = '';
-            if ($otherType instanceof Enum) {
+            if ($otherType instanceof Enum && $this->config->get('useUnderlyingEnumTypes')) {
                 $docDescription = sprintf(
                     '@see %s for valid values',
                     $otherType->getPhpNamespacedIdentifier()

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,8 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'useUnderlyingEnumTypes'        => false,
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -138,9 +138,9 @@ class Generator implements GeneratorInterface
 
             if ($typeNode->isComplex()) {
                 if ($typeNode->isArray()) {
-                    $type = new ArrayType($this->config, $typeNode->getName());
+                    $type = new ArrayType($this->config, $typeNode->getName(), $this->types);
                 } else {
-                    $type = new ComplexType($this->config, $typeNode->getName());
+                    $type = new ComplexType($this->config, $typeNode->getName(), $this->types);
                 }
 
                 $this->log('Loading type ' . $type->getPhpIdentifier());

--- a/src/Type.php
+++ b/src/Type.php
@@ -116,4 +116,9 @@ abstract class Type implements ClassGenerator
     {
         return $this->phpIdentifier;
     }
+
+    public function getPhpNamespacedIdentifier()
+    {
+        return $this->phpNamespacedIdentifier;
+    }
 }

--- a/tests/src/Unit/ComplexTypeTest.php
+++ b/tests/src/Unit/ComplexTypeTest.php
@@ -234,6 +234,7 @@ class ComplexTypeTest extends CodeGenerationTestCase
             'inputFile' => null,
             'outputDir' => null,
             'namespaceName' => $namespace,
+            'useUnderlyingEnumTypes' => true,
         ));
         $enum = new Enum($config, 'AnEnum', 'string');
         $types = TypeRegistry::fromIterable([$enum]);
@@ -259,6 +260,7 @@ class ComplexTypeTest extends CodeGenerationTestCase
         $config = new Config(array(
             'inputFile' => null,
             'outputDir' => null,
+            'useUnderlyingEnumTypes' => true,
         ));
         $enum = new Enum($config, __FUNCTION__.'Enum', 'string');
         $types = TypeRegistry::fromIterable([$enum]);
@@ -282,6 +284,7 @@ class ComplexTypeTest extends CodeGenerationTestCase
         $config = new Config(array(
             'inputFile' => null,
             'outputDir' => null,
+            'useUnderlyingEnumTypes' => true,
         ));
         $enum = new Enum($config, __FUNCTION__.'Enum', 'string');
         $types = TypeRegistry::fromIterable([$enum]);


### PR DESCRIPTION
Closes #12 

No more `@var SomeEnumClassName` as we don't *really* use the enums in generated code, but instead use the the underlying type. Enums just serve as constant containers in the generated code but are otherwise unused.