### PR TITLE
Include Type Aliases in the Generated Class Maps

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -242,9 +242,12 @@ class Service implements ClassGenerator
     protected function typesToClassmap()
     {
         $init = array();
-        foreach ($this->getTypes() as $type) {
+        foreach ($this->getTypes() as $typeAlias => $type) {
             if ($type instanceof ComplexType) {
                 $init[$type->getIdentifier()] = $this->getConfigValue('namespaceName') . "\\" . $type->getPhpIdentifier();
+                if ($typeAlias !== $type->getIdentifier()) {
+                    $init[$typeAlias] = $this->getConfigValue('namespaceName').'\\'.$type->getPhpIdentifier();
+                }
             }
         }
 


### PR DESCRIPTION
In https://github.com/AgencyPMG/wsdl2phpgenerator/pull/13 we added a
type registery with the ability to "alias" types, but didn't actually
add support for using those aliases anywhere.